### PR TITLE
Add extra steps to the "works" test

### DIFF
--- a/orcid/test_20api_all_endpoints.py
+++ b/orcid/test_20api_all_endpoints.py
@@ -97,13 +97,23 @@ class Api20AllEndPoints(OrcidBaseTest.OrcidBaseTest):
         print read_response
         #Get put-code
         putcode = self.getputcode(post_response)
+        # Check creation date after posting the item
+        search_pattern = "%s(.+?)</common:created-date>" % putcode
+        creation_date_post = re.search(search_pattern, re.sub('[\s+]', '', read_response))
+        creation_date_post = creation_date_post.group(1)
+        creation_date_post = creation_date_post.split('<common:created-date>')[1]
         #Update
         self.putjson = '{"put-code":' + str(putcode) + ',' +jsontext
         put_response = self.put20(self.putjson, postendpoint, putcode)
         self.assertTrue("200 OK" in put_response, "response: " + put_response)
         #Read Check there is no group
         read_response = self.read20(readendpoint)
+        # Check creation date after updating the item
+        creation_date_put = re.search(search_pattern, re.sub('[\s+]', '', read_response))
+        creation_date_put = creation_date_put.group(1)
+        creation_date_put = creation_date_put.split('<common:created-date>')[1]
         self.assertTrue(putname in read_response and '</activities:group><activities:group>' in re.sub('[\s+]', '', read_response), "response: " + read_response)
+        self.assertTrue(creation_date_put == creation_date_post, "post: " + creation_date_post + "; put: " + creation_date_put)
         print read_response
         #Delete
         delete_response = self.delete20(postendpoint, putcode)

--- a/orcid/test_21api_all_endpoints.py
+++ b/orcid/test_21api_all_endpoints.py
@@ -98,13 +98,23 @@ class Api20AllEndPoints(OrcidBaseTest.OrcidBaseTest):
         print read_response
         #Get put-code
         putcode = self.getputcode(post_response)
+        # Check creation date after posting the item
+        search_pattern = "%s(.+?)</common:created-date>" % putcode
+        creation_date_post = re.search(search_pattern, re.sub('[\s+]', '', read_response))
+        creation_date_post = creation_date_post.group(1)
+        creation_date_post = creation_date_post.split('<common:created-date>')[1]
         #Update
         self.putjson = '{"put-code":' + str(putcode) + ',' +jsontext
         put_response = self.put20(self.putjson, postendpoint, putcode)
         self.assertTrue("200 OK" in put_response, "response: " + put_response)
         #Read Check there is no group
         read_response = self.read20(readendpoint)
+        # Check creation date after updating the item
+        creation_date_put = re.search(search_pattern, re.sub('[\s+]', '', read_response))
+        creation_date_put = creation_date_put.group(1)
+        creation_date_put = creation_date_put.split('<common:created-date>')[1]
         self.assertTrue(putname in read_response and '</activities:group><activities:group>' in re.sub('[\s+]', '', read_response), "response: " + read_response)
+        self.assertTrue(creation_date_put == creation_date_post, "post: " + creation_date_post + "; put: " + creation_date_put)
         print read_response
         #Delete
         delete_response = self.delete20(postendpoint, putcode)

--- a/orcid/test_30api_all_endpoints.py
+++ b/orcid/test_30api_all_endpoints.py
@@ -98,13 +98,23 @@ class Api30AllEndPoints(OrcidBaseTest.OrcidBaseTest):
         print read_response
         #Get put-code
         putcode = self.getputcode(post_response)
+        # Check creation date after posting the item
+        search_pattern = "%s(.+?)</common:created-date>" % putcode
+        creation_date_post = re.search(search_pattern, re.sub('[\s+]', '', read_response))
+        creation_date_post = creation_date_post.group(1)
+        creation_date_post = creation_date_post.split('<common:created-date>')[1]
         #Update
         self.putjson = '{"put-code":' + str(putcode) + ',' +jsontext
         put_response = self.put20(self.putjson, postendpoint, putcode)
         self.assertTrue("200 OK" in put_response, "response: " + put_response)
         #Read Check there is no group
         read_response = self.read20(readendpoint)
+        # Check creation date after updating the item
+        creation_date_put = re.search(search_pattern, re.sub('[\s+]', '', read_response))
+        creation_date_put = creation_date_put.group(1)
+        creation_date_put = creation_date_put.split('<common:created-date>')[1]
         self.assertTrue(putname in read_response and '</activities:group><activities:group>' in re.sub('[\s+]', '', read_response), "response: " + read_response)
+        self.assertTrue(creation_date_put == creation_date_post, "post: " + creation_date_post + "; put: " + creation_date_put)
         print read_response
         #Delete
         delete_response = self.delete20(postendpoint, putcode)

--- a/orcid/test_30rc1api_all_endpoints.py
+++ b/orcid/test_30rc1api_all_endpoints.py
@@ -96,13 +96,23 @@ class Api30AllEndPoints(OrcidBaseTest.OrcidBaseTest):
         print read_response
         #Get put-code
         putcode = self.getputcode(post_response)
+        # Check creation date after posting the item
+        search_pattern = "%s(.+?)</common:created-date>" % putcode
+        creation_date_post = re.search(search_pattern, re.sub('[\s+]', '', read_response))
+        creation_date_post = creation_date_post.group(1)
+        creation_date_post = creation_date_post.split('<common:created-date>')[1]
         #Update
         self.putjson = '{"put-code":' + str(putcode) + ',' +jsontext
         put_response = self.put20(self.putjson, postendpoint, putcode)
         self.assertTrue("200 OK" in put_response, "response: " + put_response)
         #Read Check there is no group
         read_response = self.read20(readendpoint)
+        # Check creation date after updating the item
+        creation_date_put = re.search(search_pattern, re.sub('[\s+]', '', read_response))
+        creation_date_put = creation_date_put.group(1)
+        creation_date_put = creation_date_put.split('<common:created-date>')[1]
         self.assertTrue(putname in read_response and '</activities:group><activities:group>' in re.sub('[\s+]', '', read_response), "response: " + read_response)
+        self.assertTrue(creation_date_put == creation_date_post, "post: " + creation_date_post + "; put: " + creation_date_put)
         print read_response
         #Delete
         delete_response = self.delete20(postendpoint, putcode)

--- a/orcid/test_30rc2api_all_endpoints.py
+++ b/orcid/test_30rc2api_all_endpoints.py
@@ -98,13 +98,23 @@ class Api30AllEndPoints(OrcidBaseTest.OrcidBaseTest):
         print read_response
         #Get put-code
         putcode = self.getputcode(post_response)
+        # Check creation date after posting the item
+        search_pattern = "%s(.+?)</common:created-date>" % putcode
+        creation_date_post = re.search(search_pattern, re.sub('[\s+]', '', read_response))
+        creation_date_post = creation_date_post.group(1)
+        creation_date_post = creation_date_post.split('<common:created-date>')[1]
         #Update
         self.putjson = '{"put-code":' + str(putcode) + ',' +jsontext
         put_response = self.put20(self.putjson, postendpoint, putcode)
         self.assertTrue("200 OK" in put_response, "response: " + put_response)
         #Read Check there is no group
         read_response = self.read20(readendpoint)
+        # Check creation date after updating the item
+        creation_date_put = re.search(search_pattern, re.sub('[\s+]', '', read_response))
+        creation_date_put = creation_date_put.group(1)
+        creation_date_put = creation_date_put.split('<common:created-date>')[1]
         self.assertTrue(putname in read_response and '</activities:group><activities:group>' in re.sub('[\s+]', '', read_response), "response: " + read_response)
+        self.assertTrue(creation_date_put == creation_date_post, "post: " + creation_date_post + "; put: " + creation_date_put)
         print read_response
         #Delete
         delete_response = self.delete20(postendpoint, putcode)


### PR DESCRIPTION
The steps make sure to capture the creation date before and after a work item gets updated in order to check whether they are equal or not.